### PR TITLE
ensure s3api commands use --region

### DIFF
--- a/checks/check_extra718
+++ b/checks/check_extra718
@@ -19,10 +19,10 @@ CHECK_ALTERNATE_check718="extra718"
 
 extra718(){
   # "Check if S3 buckets have server access logging enabled (Not Scored) (Not part of CIS benchmark)"
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text|xargs -n1)
+  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --region $REGION --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_SERVER_LOG_ENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --query [LoggingEnabled] --output text 2>&1)
+      BUCKET_SERVER_LOG_ENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query [LoggingEnabled] --output text 2>&1)
       if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep AccessDenied) ]]; then
         textFail "Access Denied Trying to Get Bucket Logging for $bucket"
         continue

--- a/checks/check_extra718
+++ b/checks/check_extra718
@@ -24,7 +24,7 @@ extra718(){
     for bucket in $LIST_OF_BUCKETS;do
       BUCKET_SERVER_LOG_ENABLED=$($AWSCLI s3api get-bucket-logging --bucket $bucket $PROFILE_OPT --region $REGION --query [LoggingEnabled] --output text 2>&1)
       if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep AccessDenied) ]]; then
-        textFail "Access Denied Trying to Get Bucket Logging for $bucket"
+        textFail "Access Denied Trying to get Logging for $bucket"
         continue
       fi
       if [[ $(echo "$BUCKET_SERVER_LOG_ENABLED" | grep "^None$") ]]; then

--- a/checks/check_extra73
+++ b/checks/check_extra73
@@ -62,7 +62,7 @@ extra73(){
   #
   # Otherwise start to iterate bucket
   #
-  ALL_BUCKETS_LIST=$($AWSCLI s3api list-buckets --query 'Buckets[*].{Name:Name}' $PROFILE_OPT --output text 2>&1)
+  ALL_BUCKETS_LIST=$($AWSCLI s3api list-buckets --region $REGION --query 'Buckets[*].{Name:Name}' $PROFILE_OPT --output text 2>&1)
   if [[ $(echo "$ALL_BUCKETS_LIST" | grep AccessDenied) ]]; then
     textFail "Access Denied Trying to List Buckets"
     return
@@ -79,7 +79,7 @@ extra73(){
     # must be made to S3 endpoints in the same region as the bucket was
     # created.
     #
-    BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --bucket $bucket $PROFILE_OPT --output text 2>&1)
+    BUCKET_LOCATION=$($AWSCLI s3api get-bucket-location --region $REGION --bucket $bucket $PROFILE_OPT --output text 2>&1)
     if [[ $(echo "$BUCKET_LOCATION" | grep AccessDenied) ]]; then
       textFail "Access Denied Trying to Get Bucket Location for $bucket"
       continue

--- a/checks/check_extra763
+++ b/checks/check_extra763
@@ -19,10 +19,10 @@ CHECK_ALTERNATE_check763="extra763"
 
 extra763(){
   # "Check if S3 buckets have object versioning enabled (Not Scored) (Not part of CIS benchmark)"
-  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --query Buckets[*].Name --output text|xargs -n1)
+  LIST_OF_BUCKETS=$($AWSCLI s3api list-buckets $PROFILE_OPT --region $REGION --query Buckets[*].Name --output text|xargs -n1)
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_VERSIONING_ENABLED=$($AWSCLI s3api get-bucket-versioning --bucket $bucket $PROFILE_OPT --query Status --output text 2>&1)
+      BUCKET_VERSIONING_ENABLED=$($AWSCLI s3api get-bucket-versioning --region $REGION --bucket $bucket $PROFILE_OPT --query Status --output text 2>&1)
       if [[ $(echo "$BUCKET_VERSIONING_ENABLED" | grep AccessDenied) ]]; then
         textFail "Access Denied Trying to Get Bucket Versioning for $bucket"
         continue

--- a/checks/check_extra800
+++ b/checks/check_extra800
@@ -43,7 +43,7 @@ extra800(){
     for bucket in $LIST_OF_BUCKETS;do
       BUCKET_POLICY=$($AWSCLI s3api get-bucket-policy --region $REGION --bucket $bucket $PROFILE_OPT 2>&1)
       if [[ $(echo "$BUCKET_POLICY" | grep AccessDenied) ]]; then
-        textFail "Access Denied Trying to get Bucket Policy for $bucket"
+        textFail "Access Denied Trying to get Policy for $bucket"
         continue
       fi
 

--- a/checks/check_extra800
+++ b/checks/check_extra800
@@ -41,7 +41,7 @@ extra800(){
 
   if [[ $LIST_OF_BUCKETS ]]; then
     for bucket in $LIST_OF_BUCKETS;do
-      BUCKET_POLICY=$($AWSCLI s3api get-bucket-policy --bucket $bucket $PROFILE_OPT 2>&1)
+      BUCKET_POLICY=$($AWSCLI s3api get-bucket-policy --region $REGION --bucket $bucket $PROFILE_OPT 2>&1)
       if [[ $(echo "$BUCKET_POLICY" | grep AccessDenied) ]]; then
         textFail "Access Denied Trying to Get Bucket Logging for $bucket"
         continue

--- a/checks/check_extra800
+++ b/checks/check_extra800
@@ -43,7 +43,7 @@ extra800(){
     for bucket in $LIST_OF_BUCKETS;do
       BUCKET_POLICY=$($AWSCLI s3api get-bucket-policy --region $REGION --bucket $bucket $PROFILE_OPT 2>&1)
       if [[ $(echo "$BUCKET_POLICY" | grep AccessDenied) ]]; then
-        textFail "Access Denied Trying to Get Bucket Policy for $bucket"
+        textFail "Access Denied Trying to get Bucket Policy for $bucket"
         continue
       fi
 

--- a/checks/check_extra800
+++ b/checks/check_extra800
@@ -43,7 +43,7 @@ extra800(){
     for bucket in $LIST_OF_BUCKETS;do
       BUCKET_POLICY=$($AWSCLI s3api get-bucket-policy --region $REGION --bucket $bucket $PROFILE_OPT 2>&1)
       if [[ $(echo "$BUCKET_POLICY" | grep AccessDenied) ]]; then
-        textFail "Access Denied Trying to Get Bucket Logging for $bucket"
+        textFail "Access Denied Trying to Get Bucket Policy for $bucket"
         continue
       fi
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Some s3api queries were not specifying a region, causing AccessDenied errors on some accounts.

Also, some textFail outputs break parsing (currently, our parser does not handle "Bucket Logging", causing it to think the name of the bucket is Logging). Removing "Bucket" makes it take the bucket name after "for" without having to modify our parser. Though we should do that eventually.