### PR TITLE
Fix log metric filter checks

### DIFF
--- a/include/check3x
+++ b/include/check3x
@@ -17,7 +17,7 @@ check3x(){
   # In order to make all these checks work properly logs and alarms have to 
   # be based only on CloudTrail tail with CloudWatchLog configuration.
   DESCRIBE_TRAILS_CACHE=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[?CloudWatchLogsLogGroupArn != `null`]')
-  TRAIL_LIST=$(echo $DESCRIBE_TRAILS_CACHE | jq -r '. |@base64')
+  TRAIL_LIST=$(echo $DESCRIBE_TRAILS_CACHE | jq -r -c '.[] |@base64')
   CURRENT_ACCOUNT_ID=$($AWSCLI sts $PROFILE_OPT get-caller-identity --region "$REGION" --query Account --output text)
   CLOUDWATCH_LOGGROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text| tr '\011' '\012' | awk -F: '{print $7}')
 
@@ -35,9 +35,14 @@ check3x(){
       echo "in trail list iteration"
       group_obj_raw=$(echo $group_obj_enc | decode_report)
       echo "$group_obj_raw" | jq
-      CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[6]')
-      CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[3]')
-      CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[4]')
+      CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[6]')
+      CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[3]')
+      CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[4]')
+
+      echo CLOUDWATCH_LOGGROUP_NAME: "$CLOUDWATCH_LOGGROUP_NAME"
+      echo CLOUDWATCH_LOGGROUP_REGION: "$CLOUDWATCH_LOGGROUP_REGION"
+      echo CLOUDWATCH_LOGGROUP_ACCOUNT: "$CLOUDWATCH_LOGGROUP_ACCOUNT"
+
       if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
         # Filter control and whitespace from .metricFilters[*].filterPattern for easier matching later
         METRICFILTER_CACHE=$($AWSCLI logs describe-metric-filters --log-group-name "$CLOUDWATCH_LOGGROUP_NAME" $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION"|jq '.metricFilters|=map(.filterPattern|=gsub("[[:space:]]+"; " "))')

--- a/include/check3x
+++ b/include/check3x
@@ -38,12 +38,17 @@ check3x(){
       CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[6]')
       CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[3]')
       CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[4]')
-      if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
+
+      echo CLOUDWATCH_LOGGROUP_NAME: "$CLOUDWATCH_LOGGROUP_NAME"
+      echo CLOUDWATCH_LOGGROUP_REGION: "$CLOUDWATCH_LOGGROUP_REGION"
+      echo CLOUDWATCH_LOGGROUP_ACCOUNT: "$CLOUDWATCH_LOGGROUP_ACCOUNT"
+
+      if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then # THIS WILL ALWAYS BE FALSE IF THERE IS MORE THAN ONE LOG GROUP
         # Filter control and whitespace from .metricFilters[*].filterPattern for easier matching later
         METRICFILTER_CACHE=$($AWSCLI logs describe-metric-filters --log-group-name "$CLOUDWATCH_LOGGROUP_NAME" $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION"|jq '.metricFilters|=map(.filterPattern|=gsub("[[:space:]]+"; " "))')
         METRICFILTER_SET=$(echo $METRICFILTER_CACHE | jq -r --arg re "$grep_filter" '.metricFilters[]|select(.filterPattern|test($re))|.filterName')
       fi
-      if [[ $METRICFILTER_SET ]];then
+      if [[ $METRICFILTER_SET ]];then # And so this will always be false, too
         for metric in $METRICFILTER_SET; do
           metric_name=$(echo $METRICFILTER_CACHE | jq -r --arg name $metric '.metricFilters[]|select(.filterName==$name)|.metricTransformations[0].metricName')
           HAS_ALARM_ASSOCIATED=$($AWSCLI cloudwatch describe-alarms $PROFILE_OPT --region "$CLOUDWATCH_LOGGROUP_REGION" --query 'MetricAlarms[?MetricName==`'"$metric_name"'`]' --output text)
@@ -53,21 +58,21 @@ check3x(){
             CHECK_WARN="$CHECK_WARN $CLOUDWATCH_LOGGROUP_NAME:$metric"
           fi
         done
-      elif [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
+      elif [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then # And this will always be false (as above)
         CHECK_WARN="$CHECK_WARN $CLOUDWATCH_LOGGROUP_NAME"
       else
-        CHECK_CROSS_ACCOUNT_WARN="$CHECK_CROSS_ACCOUNT_WARN $CLOUDWATCH_LOGGROUP_NAME"
+        CHECK_CROSS_ACCOUNT_WARN="$CHECK_CROSS_ACCOUNT_WARN $CLOUDWATCH_LOGGROUP_NAME" # And so this value will always be set
       fi
     done
 
-    if [[ $CHECK_OK ]]; then
+    if [[ $CHECK_OK ]]; then # And then so will this
       for group in $CHECK_OK; do
         metric=${group#*:}
         group=${group%:*}
         textPass "CloudWatch group $group found with metric filter $metric and alarms set"
       done
     fi
-    if [[ $CHECK_WARN ]]; then
+    if [[ $CHECK_WARN ]]; then #.... And so will this
       for group in $CHECK_WARN; do
         case $group in
            *:*) metric=${group#*:}
@@ -78,9 +83,9 @@ check3x(){
         esac
       done
     fi
-    if [[ $CHECK_CROSS_ACCOUNT_WARN ]]; then
+    if [[ $CHECK_CROSS_ACCOUNT_WARN ]]; then # And so we will always arrive in this block
       for group in $CHECK_CROSS_ACCOUNT_WARN; do
-        textInfo "CloudWatch group $group is not in this account"
+        textInfo "CloudWatch group $group is not in this account" 
       done
     fi
   else

--- a/include/check3x
+++ b/include/check3x
@@ -21,9 +21,20 @@ check3x(){
   CURRENT_ACCOUNT_ID=$($AWSCLI sts $PROFILE_OPT get-caller-identity --region "$REGION" --query Account --output text)
   CLOUDWATCH_LOGGROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text| tr '\011' '\012' | awk -F: '{print $7}')
 
+  echo DESCRIBE_TRAILS_CACHE
+  echo "$DESCRIBE_TRAILS_CACHE" | jq
+  echo CLOUDWATCH_LOGGROUP
+  echo "'$CLOUDWATCH_LOGGROUP'"
+  echo CURRENT_ACCOUNT_ID
+  echo "'$CURRENT_ACCOUNT_ID'"
+  echo TRAIL_LIST
+  echo "'$TRAIL_LIST'"
+
   if [[ $CLOUDWATCH_LOGGROUP != "" ]]; then
     for group_obj_enc in $TRAIL_LIST; do
+      echo "in trail list iteration"
       group_obj_raw=$(echo $group_obj_enc | decode_report)
+      echo "$group_obj_raw" | jq
       CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[6]')
       CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[3]')
       CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.[] | .CloudWatchLogsLogGroupArn|split(":")[4]')

--- a/include/check3x
+++ b/include/check3x
@@ -17,32 +17,18 @@ check3x(){
   # In order to make all these checks work properly logs and alarms have to 
   # be based only on CloudTrail tail with CloudWatchLog configuration.
   DESCRIBE_TRAILS_CACHE=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[?CloudWatchLogsLogGroupArn != `null`]')
-  TRAIL_LIST=$(echo $DESCRIBE_TRAILS_CACHE | jq -r -c '.[] |@base64')
+  TRAIL_LIST=$(echo $DESCRIBE_TRAILS_CACHE | jq -r -c '.[] |@base64') # this treats each array element as its own line
   CURRENT_ACCOUNT_ID=$($AWSCLI sts $PROFILE_OPT get-caller-identity --region "$REGION" --query Account --output text)
   CLOUDWATCH_LOGGROUP=$($AWSCLI cloudtrail describe-trails $PROFILE_OPT --region "$REGION" --query 'trailList[*].CloudWatchLogsLogGroupArn' --output text| tr '\011' '\012' | awk -F: '{print $7}')
 
-  echo DESCRIBE_TRAILS_CACHE
-  echo "$DESCRIBE_TRAILS_CACHE" | jq
-  echo CLOUDWATCH_LOGGROUP
-  echo "'$CLOUDWATCH_LOGGROUP'"
-  echo CURRENT_ACCOUNT_ID
-  echo "'$CURRENT_ACCOUNT_ID'"
-  echo TRAIL_LIST
-  echo "'$TRAIL_LIST'"
-
   if [[ $CLOUDWATCH_LOGGROUP != "" ]]; then
     for group_obj_enc in $TRAIL_LIST; do
-      echo "in trail list iteration"
+
       group_obj_raw=$(echo $group_obj_enc | decode_report)
-      echo "$group_obj_raw" | jq
 
       CLOUDWATCH_LOGGROUP_NAME=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[6]')
       CLOUDWATCH_LOGGROUP_REGION=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[3]')
       CLOUDWATCH_LOGGROUP_ACCOUNT=$(echo $group_obj_raw | jq -r '.CloudWatchLogsLogGroupArn|split(":")[4]')
-
-      echo CLOUDWATCH_LOGGROUP_NAME: "$CLOUDWATCH_LOGGROUP_NAME"
-      echo CLOUDWATCH_LOGGROUP_REGION: "$CLOUDWATCH_LOGGROUP_REGION"
-      echo CLOUDWATCH_LOGGROUP_ACCOUNT: "$CLOUDWATCH_LOGGROUP_ACCOUNT"
 
       if [ "$CLOUDWATCH_LOGGROUP_ACCOUNT" == "$CURRENT_ACCOUNT_ID" ];then
         # Filter control and whitespace from .metricFilters[*].filterPattern for easier matching later


### PR DESCRIPTION
There was a fundamental issue with how the `check3x` (maps to our `MONITORING_#` checks) handled instances where there were multiple log groups. It attempted to loop through results, but it was treating a `jq` array as one element (and then, oddly, parsing it as an array within the loop).

It's hard to explain, but check out and run this branch: https://github.com/bridgecrewio/prowler/tree/WIP-debug-check3x on the `eab` account starting with 2287. The debug statements and code comments will make it clear why it doesn't work as expected.

The result was false-negatives whenever there were multiple log groups. There were only `info` results.

This PR fixes it by properly handling multiple elements in a jq array as distinct lines of output that can be appropriately handled in bash.

As far as I can tell, existing results still work as expected. I spot checked a handful of other instances of passing and failing resources for this check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
