### PR TITLE
update to TLS1.2 for ALBs

### DIFF
--- a/checks/check_extra792
+++ b/checks/check_extra792
@@ -71,7 +71,7 @@ extra792(){
       if [[ $LIST_OF_ELBSV2 ]]; then
         # NOTE - ALBs do NOT support custom security policies 
         # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html
-        ELBV2SECUREPOLICIES=("ELBSecurityPolicy-2016-08" "ELBSecurityPolicy-TLS-1-1-2017-01" "ELBSecurityPolicy-TLS-1-2-2017-01" "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" "ELBSecurityPolicy-FS-2018-06" "ELBSecurityPolicy-FS-1-1-2019-08" "ELBSecurityPolicy-FS-1-2-2019-08" "ELBSecurityPolicy-FS-1-2-Res-2019-08" "ELBSecurityPolicy-2015-05")
+        ELBV2SECUREPOLICIES=("ELBSecurityPolicy-TLS-1-2-2017-01" "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" "ELBSecurityPolicy-FS-1-2-2019-08" "ELBSecurityPolicy-FS-1-2-Res-2019-08")
         for elbarn in $LIST_OF_ELBSV2; do
           passed=true
           if [[ $(echo $elbarn | grep "loadbalancer/app/") ]]; then


### PR DESCRIPTION
I missed an update when I did the last PR to check only for TLS1.2 security policies. I didn't update the ALB list.

Then I will merge upstream as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
